### PR TITLE
Removed dead code after a return statement in lex.py.

### DIFF
--- a/dnslib/lex.py
+++ b/dnslib/lex.py
@@ -186,7 +186,6 @@ class WordLexer(Lexer):
                 return tok(self.lexQuote)
             elif c in self.wordchars:
                 return tok(self.lexWord)
-                return (self.spacetok,self.lexWord)
             elif c:
                 raise ValueError("Invalid input [%d]: %s" % (
                                         self.f.tell(),c))


### PR DESCRIPTION
Hello,
In testing an experimental [tool my company wrote](https://github.com/returntocorp/sgrep) for matching code patterns, I stumbled across your codebase which had a dead return statement in WordLexer.lexSpace. I took a look at it and it seems like removing the dead code doesn't affect anything. It looks like the intention of that line is now covered by:

```python
if self.spacetok: # Line 173
    tok = lambda n : (self.spacetok,n) if s else (None,n)
```

so I removed the dead return and am making this PR.

If you're curious, here's the rule which catches dead code after return statements. https://github.com/returntocorp/sgrep-rules/blob/cfa3d186f2690a630616c348f208c8677aaf2173/python/deadcode/return.yaml

I hope my inference about the dead code's purpose is correct and that removing it doesn't cause any problems. All tests still pass since functionality remains the same. :)

Let me know if you have any questions!