### PR TITLE
Return doctest status via exit code

### DIFF
--- a/dnslib/__init__.py
+++ b/dnslib/__init__.py
@@ -375,6 +375,5 @@ from dnslib.dns import *
 version = "0.9.13"
 
 if __name__ == '__main__':
-    import doctest,textwrap
-    doctest.testmod(optionflags=doctest.ELLIPSIS)
-
+    import doctest,sys,textwrap
+    sys.exit(0 if doctest.testmod(optionflags=doctest.ELLIPSIS).failed == 0 else 1)

--- a/dnslib/bimap.py
+++ b/dnslib/bimap.py
@@ -77,5 +77,5 @@ class Bimap(object):
             raise self.error("%s: Invalid reverse lookup: [%s]" % (self.name,k))
 
 if __name__ == '__main__':
-    import doctest
-    doctest.testmod()
+    import doctest,sys
+    sys.exit(0 if doctest.testmod().failed == 0 else 1)

--- a/dnslib/bit.py
+++ b/dnslib/bit.py
@@ -84,6 +84,5 @@ def binary(n,count=16,reverse=False):
     return "".join(bits)
 
 if __name__ == '__main__':
-    import doctest
-    doctest.testmod()
-
+    import doctest,sys
+    sys.exit(0 if doctest.testmod().failed == 0 else 1)

--- a/dnslib/buffer.py
+++ b/dnslib/buffer.py
@@ -110,5 +110,5 @@ class Buffer(object):
         return len(self.data)
 
 if __name__ == '__main__':
-    import doctest
-    doctest.testmod()
+    import doctest,sys
+    sys.exit(0 if doctest.testmod().failed == 0 else 1)

--- a/dnslib/client.py
+++ b/dnslib/client.py
@@ -142,4 +142,3 @@ if __name__ == '__main__':
 
     except DNSError as e:
         p.error(e)
-

--- a/dnslib/digparser.py
+++ b/dnslib/digparser.py
@@ -230,4 +230,4 @@ if __name__ == '__main__':
         for record in l:
             print(repr(record))
     else:
-        doctest.testmod()
+        sys.exit(0 if doctest.testmod().failed == 0 else 1)

--- a/dnslib/dns.py
+++ b/dnslib/dns.py
@@ -1859,5 +1859,5 @@ class ZoneParser:
                 yield self.parse_rr(rr)
 
 if __name__ == '__main__':
-    import doctest
-    doctest.testmod(optionflags=doctest.ELLIPSIS)
+    import doctest,sys
+    sys.exit(0 if doctest.testmod(optionflags=doctest.ELLIPSIS).failed == 0 else 1)

--- a/dnslib/label.py
+++ b/dnslib/label.py
@@ -308,5 +308,5 @@ class DNSBuffer(Buffer):
         self.append(b'\x00')
 
 if __name__ == '__main__':
-    import doctest
-    doctest.testmod()
+    import doctest,sys
+    sys.exit(0 if doctest.testmod().failed == 0 else 1)

--- a/dnslib/lex.py
+++ b/dnslib/lex.py
@@ -347,7 +347,7 @@ if __name__ == '__main__':
         try:
             # Test if we have /dev/urandom
             open("/dev/urandom")
-            doctest.testmod()
+            sys.exit(0 if doctest.testmod().failed == 0 else 1)
         except IOError:
             # Don't run stream test
             doctest.run_docstring_examples(Lexer, globals())

--- a/dnslib/ranges.py
+++ b/dnslib/ranges.py
@@ -136,6 +136,5 @@ def IP6(attr):
     return ntuple_range(attr,16,0,255)
 
 if __name__ == '__main__':
-    import doctest
-    doctest.testmod(optionflags=doctest.ELLIPSIS)
-
+    import doctest,sys
+    sys.exit(0 if doctest.testmod(optionflags=doctest.ELLIPSIS).failed == 0 else 1)

--- a/dnslib/server.py
+++ b/dnslib/server.py
@@ -362,5 +362,5 @@ class DNSServer(object):
         return self.thread.is_alive()
 
 if __name__ == "__main__":
-    import doctest
-    doctest.testmod(optionflags=doctest.ELLIPSIS)
+    import doctest,sys
+    sys.exit(0 if doctest.testmod(optionflags=doctest.ELLIPSIS).failed == 0 else 1)


### PR DESCRIPTION
Exit with unsuccessful code if doctests fail.  This makes it possible
to actually automate running tests without relying on ugly greps
to figure out if they worked.