### PR TITLE
Use chain.from_iterable in dns.py

### DIFF
--- a/dnslib/dns.py
+++ b/dnslib/dns.py
@@ -1164,8 +1164,8 @@ def _parse_ipv6(a):
 
     """
     l,_,r = a.partition("::")
-    l_groups = list(chain(*[divmod(int(x,16),256) for x in l.split(":") if x]))
-    r_groups = list(chain(*[divmod(int(x,16),256) for x in r.split(":") if x]))
+    l_groups = list(chain.from_iterable(divmod(int(x,16),256) for x in l.split(":") if x))
+    r_groups = list(chain.from_iterable(divmod(int(x,16),256) for x in r.split(":") if x))
     zeros = [0] * (16 - len(l_groups) - len(r_groups))
     return tuple(l_groups + zeros + r_groups)
 


### PR DESCRIPTION
This is a faster and more idiomatic way of using `itertools.chain`. Instead of computing all the items in the iterable and storing them in memory, they are computed one-by-one and never stored as a huge list. This can save on both runtime and memory space.