### PR TITLE
RFC2782, page 3: DNS SRV Target must not be compressed

### DIFF
--- a/dnslib/dns.py
+++ b/dnslib/dns.py
@@ -1454,7 +1454,7 @@ class SRV(RD):
 
     def pack(self,buffer):
         buffer.pack("!HHH",self.priority,self.weight,self.port)
-        buffer.encode_name(self.target)
+        buffer.encode_name_nocompress(self.target)
 
     def __repr__(self):
         return "%d %d %d %s" % (self.priority,self.weight,self.port,self.target)

--- a/dnslib/label.py
+++ b/dnslib/label.py
@@ -294,7 +294,7 @@ class DNSBuffer(Buffer):
     def encode_name_nocompress(self,name):
         """
             Encode and store label with no compression
-            (needed for RRSIG)
+            (needed for RRSIG, SRV, NSEC)
         """
         if not isinstance(name,DNSLabel):
             name = DNSLabel(name)


### PR DESCRIPTION
No name compression, line 1457 dns.py

Added SRV and NSEC to list of RR using no name compression, line 297 label.py